### PR TITLE
исправление ошибки с лишним пробелом в методе toString

### DIFF
--- a/lib/YandexMoney/Utils/RightsConfigurator.php
+++ b/lib/YandexMoney/Utils/RightsConfigurator.php
@@ -64,7 +64,7 @@ class RightsConfigurator
         if(empty($this->rightsString)) {
             $this->rightsString = Rights::ACCOUNT_INFO . " " . Rights::OPERATION_HISTORY;
         }
-        return $this->rightsString;
+        return trim($this->rightsString);
     }
 
     /**


### PR DESCRIPTION
Лишний хвостовой пробел приводил к ошибке авторизации.
Приходилось его обрезать уже на своей стороне.

Было: string(49) "account-info operation-history operation-details "
Стало: string(48) "account-info operation-history operation-details"
