### PR TITLE
Bug fix: Incorrect path to certificate

### DIFF
--- a/lib/YandexMoney/Utils/ApiNetworkClient.php
+++ b/lib/YandexMoney/Utils/ApiNetworkClient.php
@@ -14,7 +14,7 @@ class ApiNetworkClient
     /**
      *
      */
-    const CERTIFICATE_PATH = '/../../Data/ca-certificate.crt';
+    const CERTIFICATE_PATH = '/../../data/ca-certificate.crt';
 
     /**
      * @var string


### PR DESCRIPTION
On UNIX systems paths are case-sensitive unlike Windows systems. As a result the uppercase-defined path led to a CURLE_SSL_CACERT_BADFILE (77) error.
