### PR TITLE
Fix deprecated URL in API

### DIFF
--- a/lib/api.php
+++ b/lib/api.php
@@ -184,7 +184,7 @@ class API extends BaseAPI {
             "client_id=%s&response_type=%s&redirect_uri=%s&scope=%s",
             $client_id, "code", $redirect_uri, implode(" ", $scope)
             );
-        return sprintf("%s/oauth/authorize?%s", Config::$SP_MONEY_URL, $params);
+        return sprintf("%s/oauth/authorize?%s", Config::$MONEY_URL, $params);
     }
 
     /**
@@ -205,7 +205,7 @@ class API extends BaseAPI {
      */
     public static function getAccessToken($client_id, $code, $redirect_uri,
             $client_secret=NULL) {
-        $full_url = Config::$SP_MONEY_URL . "/oauth/token";
+        $full_url = Config::$MONEY_URL . "/oauth/token";
         return self::sendRequest($full_url, array(
             "code" => $code,
             "client_id" => $client_id,

--- a/lib/base.php
+++ b/lib/base.php
@@ -1,15 +1,14 @@
-<?php 
+<?php
 namespace YandexMoney;
 
 require_once __DIR__ . "/exceptions.php";
 
 class Config {
     static $MONEY_URL = "https://money.yandex.ru";
-    static $SP_MONEY_URL = "https://sp-money.yandex.ru";
 }
 
 class BaseAPI {
-    
+
     public static function sendRequest($url, $options=array(), $access_token=NULL) {
         if(strpos($url, "https") === false) {
             $full_url= Config::$MONEY_URL . $url;
@@ -32,6 +31,7 @@ class BaseAPI {
         curl_setopt($curl, CURLOPT_HEADER, 0);
         //curl_setopt($curl, CURLOPT_VERBOSE, 1);
         curl_setopt ($curl, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt ($curl, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt ($curl, CURLOPT_SSL_VERIFYHOST, 2);
         $body = curl_exec ($curl);
 
@@ -45,13 +45,13 @@ class BaseAPI {
     protected static function processResult($result) {
         switch ($result->status_code) {
             case 400:
-                throw new Exceptions\FormatError; 
+                throw new Exceptions\FormatError;
                 break;
             case 401:
-                throw new Exceptions\TokenError; 
+                throw new Exceptions\TokenError;
                 break;
             case 403:
-                throw new Exceptions\ScopeError; 
+                throw new Exceptions\ScopeError;
                 break;
             default:
                 if($result->status_code >= 500) {


### PR DESCRIPTION
Updated due to current documentation
https://tech.yandex.ru/money/doc/dg/concepts/money-oauth-intro-docpage/